### PR TITLE
No longer redraws all tracks on label edit/delete

### DIFF
--- a/js/Store/SeqFeature/Features.js
+++ b/js/Store/SeqFeature/Features.js
@@ -32,7 +32,7 @@ function (
                 });
             }
         },
-        addFeature: function(query){
+        addFeature: function(query, callback){
             var features = JSON.parse(localStorage.getItem(this.config.label) || '[]');
 
             query['label'] = 'unknown';
@@ -40,8 +40,10 @@ function (
             features.push(query);
 
             localStorage.setItem(this.config.label, JSON.stringify(features));
+
+            callback()
         },
-        updateFeature(query)
+        updateFeature(query, callback)
         {
             var features = JSON.parse(localStorage.getItem(this.config.label));
 
@@ -58,8 +60,10 @@ function (
             });
 
             localStorage.setItem(this.config.label, JSON.stringify(features))
+
+            callback()
         },
-        removeFeature(query)
+        removeFeature(query, callback)
         {
             var features = JSON.parse(localStorage.getItem(this.config.label));
 
@@ -73,6 +77,8 @@ function (
             });
 
             localStorage.setItem(this.config.label, JSON.stringify(features))
+
+            callback()
         },
         saveStore() {
             return {

--- a/js/View/Track/MultiXYPlot.js
+++ b/js/View/Track/MultiXYPlot.js
@@ -12,14 +12,17 @@ function (
         {
             constructor: function(args)
             {
-                var newLabel = (data) => {
+                const newCallback = () => {
+                    args.browser.clearHighlight();
+                    this.browser.view.behaviorManager.swapBehaviors('highlightingMouse', 'normalMouse');
+                };
+
+                const newLabel = (data) => {
                     if (data.length) {
                         // add new highlight to storage
                         var dataVal = data[0];
                         dataVal['name'] = this.name;
-                        this.highlightStore.addFeature(dataVal);
-                        args.browser.clearHighlight();
-                        this.browser.view.behaviorManager.swapBehaviors('highlightingMouse', 'normalMouse');
+                        this.highlightStore.addFeature(dataVal, newCallback);
                     }
                 };
 
@@ -43,12 +46,13 @@ function (
                                         'end': feature.get('end'),
                                         'label': states[(i+1)%states.length]
                                     }
-                                    this.highlightStore.updateFeature(args);
+                                    redrawCallback = () => {
+                                        track.redraw()
+                                    }
+                                    this.highlightStore.updateFeature(args, redrawCallback);
                                     break;
                                 }
                             }
-
-                            track.redraw();
                         },
                         onHighlightRightClick: function( feature, track ) {
                             // json of information of removed label
@@ -58,11 +62,11 @@ function (
                                 'end': feature.get('end')
                             };
 
-                            this.highlightStore.removeFeature(removeJSON);
-                            // redraw to update model
-                            track.redraw();
+                            redrawCallback = () => {
+                                        track.redraw()
+                                    }
 
-                            return false;
+                            this.highlightStore.removeFeature(removeJSON, redrawCallback());
                         },
                         highlightColor: function (feature, track) {
                             // determins the color of the see through part of the label

--- a/js/View/Track/MultiXYPlot.js
+++ b/js/View/Track/MultiXYPlot.js
@@ -12,17 +12,14 @@ function (
         {
             constructor: function(args)
             {
-                const newCallback = () => {
-                    args.browser.clearHighlight();
-                    this.browser.view.behaviorManager.swapBehaviors('highlightingMouse', 'normalMouse');
-                };
-
-                const newLabel = (data) => {
+                let newLabel = (data) => {
                     if (data.length) {
                         // add new highlight to storage
                         var dataVal = data[0];
                         dataVal['name'] = this.name;
-                        this.highlightStore.addFeature(dataVal, newCallback);
+                        this.highlightStore.addFeature(dataVal);
+                        this.browser.clearHighlight();
+                        this.browser.view.behaviorManager.swapBehaviors('highlightingMouse', 'normalMouse');
                     }
                 };
 

--- a/js/View/Track/MultiXYPlot.js
+++ b/js/View/Track/MultiXYPlot.js
@@ -60,10 +60,11 @@ function (
                             };
 
                             let redrawCallback = () => {
+
                                         track.redraw()
                                     }
 
-                            this.highlightStore.removeFeature(removeJSON, redrawCallback());
+                            this.highlightStore.removeFeature(removeJSON, redrawCallback);
                         },
                         highlightColor: function (feature, track) {
                             // determins the color of the see through part of the label

--- a/js/View/Track/MultiXYPlot.js
+++ b/js/View/Track/MultiXYPlot.js
@@ -19,6 +19,7 @@ function (
                         dataVal['name'] = this.name;
                         this.highlightStore.addFeature(dataVal);
                         args.browser.clearHighlight();
+                        this.browser.view.behaviorManager.swapBehaviors('highlightingMouse', 'normalMouse');
                     }
                 };
 
@@ -32,7 +33,7 @@ function (
                             const states = ['unknown', 'peak', 'noPeak', 'peakStart', 'peakEnd'];
                             // label add to this list and the two down below for determining the color
                             // loops through known labels for the label clicked
-                            for(i = 0; i < states.length; i++)
+                            for(let i = 0; i < states.length; i++)
                             {
                                 if( feature.get('label') === states[i] )
                                 {

--- a/js/View/Track/MultiXYPlot.js
+++ b/js/View/Track/MultiXYPlot.js
@@ -37,13 +37,13 @@ function (
                             {
                                 if( feature.get('label') === states[i] )
                                 {
-                                    var args = {
+                                    let args = {
                                         'ref': feature.get('ref'),
                                         'start': feature.get('start'),
                                         'end': feature.get('end'),
                                         'label': states[(i+1)%states.length]
                                     }
-                                    redrawCallback = () => {
+                                    let redrawCallback = () => {
                                         track.redraw()
                                     }
                                     this.highlightStore.updateFeature(args, redrawCallback);
@@ -53,13 +53,13 @@ function (
                         },
                         onHighlightRightClick: function( feature, track ) {
                             // json of information of removed label
-                            var removeJSON = {
+                            let removeJSON = {
                                 'ref': feature.get('ref'),
                                 'start': feature.get('start'),
                                 'end': feature.get('end')
                             };
 
-                            redrawCallback = () => {
+                            let redrawCallback = () => {
                                         track.redraw()
                                     }
 

--- a/js/View/Track/MultiXYPlot.js
+++ b/js/View/Track/MultiXYPlot.js
@@ -47,7 +47,7 @@ function (
                                 }
                             }
 
-                            track.browser.view.redrawTracks();
+                            track.redraw();
                         },
                         onHighlightRightClick: function( feature, track ) {
                             // json of information of removed label
@@ -59,7 +59,9 @@ function (
 
                             this.highlightStore.removeFeature(removeJSON);
                             // redraw to update model
-                            track.browser.view.redrawTracks()
+                            track.redraw();
+
+                            return false;
                         },
                         highlightColor: function (feature, track) {
                             // determins the color of the see through part of the label


### PR DESCRIPTION
Given the previous changes, all tracks no longer need to be redrawn for an edit/delete. 